### PR TITLE
Small change to allow replayfiles to be stored in one specific folder, and a security fix

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -1,5 +1,6 @@
 SOURCES=$(addsuffix .cpp, Snipes $(addprefix sdl/, console keyboard sound timer))
-CFLAGS=-std=c++11 $(shell sdl2-config --cflags)
+# CFLAGS=-std=c++11 $(shell sdl2-config --cflags)
+CFLAGS=-std=c++23 $(shell sdl2-config --cflags)
 CFLAGS+=$(if $(MAINT),-Werror -Wall -Wextra,)
 CFLAGS2=-O3 -fstack-protector
 #CFLAGS2=-Og -g -fsanitize=address -fsanitize=undefined

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -1,6 +1,5 @@
 SOURCES=$(addsuffix .cpp, Snipes $(addprefix sdl/, console keyboard sound timer))
-# CFLAGS=-std=c++11 $(shell sdl2-config --cflags)
-CFLAGS=-std=c++23 $(shell sdl2-config --cflags)
+CFLAGS=-std=c++11 $(shell sdl2-config --cflags)
 CFLAGS+=$(if $(MAINT),-Werror -Wall -Wextra,)
 CFLAGS2=-O3 -fstack-protector
 #CFLAGS2=-Og -g -fsanitize=address -fsanitize=undefined

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Snipes
 
-This is a modern port of the classic 1982 text-mode game Snipes. The code has been reverse-engineered from the original DOS executable, and has 100% identical game logic. 
+This is a modern port of the classic 1982 text-mode game Snipes. The code has been reverse-engineered from the original DOS executable, and has 100% identical game logic.
 
 For more information, see the [vogons.org forum thread](https://www.vogons.org/viewtopic.php?f=7&t=49073).
 
@@ -28,6 +28,7 @@ For Arch Linux, you can use the [snipes-git](https://aur.archlinux.org/packages/
 ### Replay recording
 
 This version automatically records replay files of played games. By default, replay files are saved to the current directory, and have a `.SnipesGame` file extension.
+If you uncomment the `#define REPLAY_FOLDER` line in config.h and enter a valid path, the `.SnipesGame` replays will be saved to that directory rather than the current directory.
 
 To play back a replay file, pass it as the first argument to the game program, e.g.:
 

--- a/Snipes.cpp
+++ b/Snipes.cpp
@@ -13,6 +13,17 @@
 #include "keyboard.h"
 #include "platform.h"
 
+
+// Platform-specific directory creation
+#if defined(_WIN32) || defined(_WIN64)
+	#include <direct.h>
+	#define CREATE_DIRECTORY(path) _mkdir(path)
+#else
+	#include <sys/stat.h>
+	#include <sys/types.h>
+	#define CREATE_DIRECTORY(path) mkdir(path, 0755)
+#endif
+
 bool got_ctrl_break = false;
 bool forfeit_match = false;
 bool instant_quit = false;
@@ -1733,7 +1744,7 @@ void EraseObjectFromMaze()
 	}
 }
 
-//template <typename TYPE> TYPE &IncWrap(TYPE &n, 
+//template <typename TYPE> TYPE &IncWrap(TYPE &n,
 
 void UpdateSnipePortals()
 {
@@ -2271,9 +2282,13 @@ extern "C" int __cdecl SDL_main(int argc, char* argv[])
 			struct tm *rectime_gmt;
 			rectime_gmt = gmtime(&rectime);
 
-			char replayFilename[1024];
+			// Create the replay folder if it doesn't exist
+			CREATE_DIRECTORY(REPLAY_FOLDER);
+
+            char replayFilename[1024];
 			sprintf(replayFilename,
-					"%04d-%02d-%02d %02d.%02d.%02d.SnipesGame",
+					"%s/%04d-%02d-%02d %02d.%02d.%02d.SnipesGame",
+					REPLAY_FOLDER,
 					1900+rectime_gmt->tm_year, rectime_gmt->tm_mon+1, rectime_gmt->tm_mday,
 					rectime_gmt->tm_hour, rectime_gmt->tm_min, rectime_gmt->tm_sec);
 

--- a/Snipes.cpp
+++ b/Snipes.cpp
@@ -2281,16 +2281,23 @@ extern "C" int __cdecl SDL_main(int argc, char* argv[])
 			time_t rectime = time(NULL);
 			struct tm *rectime_gmt;
 			rectime_gmt = gmtime(&rectime);
-
+#ifdef REPLAY_FOLDER
 			// Create the replay folder if it doesn't exist
 			CREATE_DIRECTORY(REPLAY_FOLDER);
 
             char replayFilename[1024];
-			sprintf(replayFilename,
+            snprintf(replayFilename, sizeof(replayFilename),
 					"%s/%04d-%02d-%02d %02d.%02d.%02d.SnipesGame",
 					REPLAY_FOLDER,
 					1900+rectime_gmt->tm_year, rectime_gmt->tm_mon+1, rectime_gmt->tm_mday,
 					rectime_gmt->tm_hour, rectime_gmt->tm_min, rectime_gmt->tm_sec);
+#else
+            char replayFilename[1024];
+            snprintf(replayFilename, sizeof(replayFilename),
+                    "%04d-%02d-%02d %02d.%02d.%02d.SnipesGame",
+                    1900+rectime_gmt->tm_year, rectime_gmt->tm_mon+1, rectime_gmt->tm_mday,
+                    rectime_gmt->tm_hour, rectime_gmt->tm_min, rectime_gmt->tm_sec);
+#endif
 
 #ifdef CHEAT
 			replayFile = fopen(replayFilename, "w+b");

--- a/Snipes.cpp
+++ b/Snipes.cpp
@@ -24,6 +24,11 @@
 	#define CREATE_DIRECTORY(path) mkdir(path, 0755)
 #endif
 
+//IF REPLAY_FOLDER is not defined, it should use the current folder.
+#ifndef REPLAY_FOLDER
+    #define REPLAY_FOLDER "."
+#endif
+
 bool got_ctrl_break = false;
 bool forfeit_match = false;
 bool instant_quit = false;
@@ -2281,7 +2286,7 @@ extern "C" int __cdecl SDL_main(int argc, char* argv[])
 			time_t rectime = time(NULL);
 			struct tm *rectime_gmt;
 			rectime_gmt = gmtime(&rectime);
-#ifdef REPLAY_FOLDER
+
 			// Create the replay folder if it doesn't exist
 			CREATE_DIRECTORY(REPLAY_FOLDER);
 
@@ -2291,13 +2296,6 @@ extern "C" int __cdecl SDL_main(int argc, char* argv[])
 					REPLAY_FOLDER,
 					1900+rectime_gmt->tm_year, rectime_gmt->tm_mon+1, rectime_gmt->tm_mday,
 					rectime_gmt->tm_hour, rectime_gmt->tm_min, rectime_gmt->tm_sec);
-#else
-            char replayFilename[1024];
-            snprintf(replayFilename, sizeof(replayFilename),
-                    "%04d-%02d-%02d %02d.%02d.%02d.SnipesGame",
-                    1900+rectime_gmt->tm_year, rectime_gmt->tm_mon+1, rectime_gmt->tm_mday,
-                    rectime_gmt->tm_hour, rectime_gmt->tm_min, rectime_gmt->tm_sec);
-#endif
 
 #ifdef CHEAT
 			replayFile = fopen(replayFilename, "w+b");

--- a/config-sample.h
+++ b/config-sample.h
@@ -18,6 +18,9 @@
 // For playback: Wait for a keypress at start, and behave like a live game at end. Meant for screen recording of a played back replay.
 //#define PLAYBACK_FOR_SCREEN_RECORDING
 
+// Store Recording files to a single folder. This should ensure playback that the game doesn't develop a __MACOSX problem.
+#define PLAYBACKFOLDER "~/SnipesGameFiles"
+
 // Windows options
 #define WINDOWS_PRECISE_TIMER
 

--- a/config-sample.h
+++ b/config-sample.h
@@ -18,8 +18,13 @@
 // For playback: Wait for a keypress at start, and behave like a live game at end. Meant for screen recording of a played back replay.
 //#define PLAYBACK_FOR_SCREEN_RECORDING
 
-// Store Recording files to a single folder. This should ensure playback that the game doesn't develop a __MACOSX problem.
-#define PLAYBACKFOLDER "~/SnipesGameFiles"
+// Store Recording files to a single folder.
+// This should ensure playback that the game doesn't develop a __MACOSX problem where there are SnipesGameFiles littered everywhere.
+// For Linux: (note, you can't use the ~/SnipesGameFiles naming format)
+#define PLAYBACKFOLDER "/home/username/SnipesGameFiles"
+//
+// For Windows:
+// #define PLAYBACKFOLDER "C:\SnipesGameFiles"
 
 // Windows options
 #define WINDOWS_PRECISE_TIMER

--- a/config-sample.h
+++ b/config-sample.h
@@ -21,7 +21,7 @@
 // Store Recording files to a single folder.
 // This should ensure playback that the game doesn't develop a __MACOSX problem where there are SnipesGameFiles littered everywhere.
 // For Linux: (note, you can't use the ~/SnipesGameFiles naming format)
-#define PLAYBACKFOLDER "/home/username/SnipesGameFiles"
+#define REPLAY_FOLDER "/home/username/SnipesGameFiles"
 //
 // For Windows:
 // #define PLAYBACKFOLDER "C:\SnipesGameFiles"


### PR DESCRIPTION
This change add an option to allow SnipesGamesFiles to be stored in a specific folder. I added this because I tend to start snipes without checking what folder I'm in. This allows the files to be stored in one place.

I've also updated the filename generation code to use `snprintf` instead of `sprintf` to reduce the risk of a buffer overflow if someone supplies too long a folder name.